### PR TITLE
Support for ngCookies < 1.4.x

### DIFF
--- a/src/angular-consent/controllers/consent.js
+++ b/src/angular-consent/controllers/consent.js
@@ -11,11 +11,23 @@
     };
 
     this.getCookieValue = function(){
-      return $cookies.get(this.getCookieKey());
+      try {
+        return $cookies.get(this.getCookieKey())
+      } catch (e) {
+        if (e instanceof TypeError){
+          return $cookies[this.getCookieKey()];
+        }
+      }
     };
 
     this.setCookieValue = function(value){
-      return $cookies.put(this.getCookieKey(), value);
+      try {
+        $cookies.put(this.getCookieKey(), value)
+      } catch (e) {
+        if (e instanceof TypeError){
+          $cookies[this.getCookieKey()] = value ;
+        }
+      }
     };
 
     this.hasAlreadyAgreed = function(){
@@ -30,7 +42,13 @@
     };
 
     this.reset = function(){
-      $cookies.remove(this.getCookieKey());
+      try {
+        $cookies.remove(this.getCookieKey())
+      } catch (e) {
+        if (e instanceof TypeError){
+          delete $cookies[this.getCookieKey()];
+        }
+      }
     };
 
     this.agree = function(){


### PR DESCRIPTION
This PR contains an enhancement to the cookie getter and setter methods in the controller.

There was a breaking API change in `ngCookies` from Angular `1.3.x` to `1.4x`, which will result in throwing a `TypeError` if anyone using this is on Angular < 1.4
http://stackoverflow.com/questions/28971126/angular-and-cookies-cookies-get-is-not-a-function

In your `bower.json` the project's dev dependencies say `"angular": ">=1.2.0"`, so it should be able to handle both versions of `ngCookies`.

My solution checks for `TypeError` and then uses the older API syntax to get/set cookies.
