### PR TITLE
Add main entry point in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "angular-consent",
+  "main": "dist/angular-consent.js",
   "version": "2.1.1",
   "author": {
     "name": "Jurgen Van de Moere",


### PR DESCRIPTION
I was having trouble using this library with the syntax `import 'angular-consent';` and webpack. Without being an expert in npm, it looks like adding a main entry in package.json fixes the problem. Was it on purpose that you did not make one in the first time?